### PR TITLE
Fix #1 (bad credential input loops)

### DIFF
--- a/captive_portal.py
+++ b/captive_portal.py
@@ -77,6 +77,7 @@ class CaptivePortal:
         )
         # forget the credentials since they didn't work, and turn off station mode
         self.ssid = self.password = None
+        self.http_server.saved_credentials = (None, None)
         self.sta_if.active(False)
         return False
 


### PR DESCRIPTION
Prevents endlessly looping through WiFi connect sequence if the given credentials are incorrect.