### PR TITLE
ESP8266 cannot save the ssid and password.

### DIFF
--- a/captive_portal.py
+++ b/captive_portal.py
@@ -112,7 +112,8 @@ class CaptivePortal:
         return None not in [self.ssid, self.password]
 
     def write_creds(self, ssid, password):
-        open(self.CRED_FILE, "wb").write(b",".join([ssid, password]))
+        with open(self.CRED_FILE, "wb") as fp:
+          fp.write(b",".join([ssid, password]))
         print("Wrote credentials to {:s}".format(self.CRED_FILE))
 
     def captive_portal(self):


### PR DESCRIPTION
… we should close it. If it is not closed, ESP8266 wil not save "ssid" and "password".